### PR TITLE
remove_stop_words added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ parts/
 sdist/
 var/
 wheels/
+.idea/
 pip-wheel-metadata/
 share/python-wheels/
 *.egg-info/

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -38,3 +38,8 @@ class TestNormalizer(TestCase):
         self.assertEqual(
             Normalizer.convert_text_numbers(text), "iki virgül beş kilgoram şeker ve iki adet ekmek alabilir miyim?"
         )
+
+    def test_remove_stop_words(self):
+        text = "Bugün hava çok güzel ve ben çok iyi hissediyorum."
+        self.assertEqual(Normalizer.remove_stop_words(text), "hava hissediyorum.")
+

--- a/tnltk/normalizer/normalizer.py
+++ b/tnltk/normalizer/normalizer.py
@@ -136,3 +136,30 @@ class Normalizer:
                 return warnings.warn("In Turkish language, decimal numbers are expressed with commas.")
 
         return re.sub(r"[-+]?\d*.\d+|\d+", convert_number, text.replace(",", " virgül ")).lstrip()
+
+
+    @staticmethod
+    def remove_stop_words(text:str) -> str:
+        """
+        Removes stop words from the given string.
+
+        Parameters
+        ----------
+        text : str
+            Input text.
+
+        Returns
+        -------
+        text : str
+            Text stripped from stop words.
+
+        Example:
+        --------
+        >>> from tnltk import Normalizer
+        >>> Normalizer.remove_stop_words("Bugün hava çok güzel ve ben çok iyi hissediyorum.")
+        'bugün hava güzel ben iyi hissediyorum.'.
+        """
+        with open('resources/TR_stop_words.txt', 'r', encoding='utf-8') as f:
+            stop = [line.strip() for line in f]
+        return ' '.join([word for word in text.split() if word.lower() not in stop])
+

--- a/tnltk/normalizer/normalizer.py
+++ b/tnltk/normalizer/normalizer.py
@@ -157,7 +157,7 @@ class Normalizer:
         --------
         >>> from tnltk import Normalizer
         >>> Normalizer.remove_stop_words("Bugün hava çok güzel ve ben çok iyi hissediyorum.")
-        'bugün hava güzel ben iyi hissediyorum.'.
+        'hava hissediyorum.'.
         """
         with open('resources/TR_stop_words.txt', 'r', encoding='utf-8') as f:
             stop = [line.strip() for line in f]


### PR DESCRIPTION
stop words türkçe için de büyük bir problem. resource içinde bulunan 250~ kelimelik stop words kütüphanesi yeterli olmayacaktır. daha kapsamlı bir kütüphane ile daha başarılı temizleme yapılabilir.

word.lower() kullanılmasının sebebi, "Çünkü" ile başlayan cümlelerde, stop words içerisinde geçen "çünkü" kelimesi yakalanamayabiliyor. Bu sebepten ötürü standardize olması adına .lower() kullanıldı.

Stop-words'lerin olduğu text dosyası okunurken encoding'e dikkat edilmesi önem arz ediyor,

PyCharm ile çalışırken otomatik olarak ".idea" isimli klasör oluşturuyor, bu sebepten ötürü .gitignore'a eklendi